### PR TITLE
Pool directive with restrict nopeer needs "restrict source"

### DIFF
--- a/run
+++ b/run
@@ -239,9 +239,15 @@ def ntp_set_servers(node, assoc_mode, server_list, keep_local = True):
 		if len(words) >= 2 and words[0] in assoc_type_list:
 			if words[1] != "127.127.1.0" or not(keep_local):
 				continue
+		# If you can find "restrict source" then do not append the line, bsc#981828
+		if len(words) >= 2 and words[0] == "restrict" and words[1] == "source":
+                                continue
 		out.append(line)
 
 	for server in server_list:
+		# If you are using "pool" directive, then append "restrict source", bsc#981828
+		if assoc_mode == "pool":
+			out.append("restrict source")
 		out.append("%s %s iburst" % (assoc_mode, server))
 
 	# Upload the changed ntp.conf


### PR DESCRIPTION
Please forward to master. This change is mandatory for openQA but it can pass in SLEnkins even withou this change. According to the man page the Line "restrict sources" in ntp.conf is mandatory for combination of "pool" directive and "restrict \* nopeer"...
# man ntp.conf restrict/nopeer:

> Deny packets which would result in mobilizing a  new association. 
> This includes broadcast  and  symmetric  active  packets  when  a configured 
> association does not exist.  It also includes pool associations, so if you
> want to use  servers  from  a pool  directive  and  also  want  to  use 
> nopeer by default, you'll want a restrict  source ... line as well that does

Possible security bug filled BSC#981828
